### PR TITLE
Add JURMAQ Spanish landing page with responsive styles and JSON-LD

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,303 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>JURMAQ | Arriendo de maquinaria, constructora y barraca en Curicó</title>
+    <meta
+      name="description"
+      content="JURMAQ: arriendo de maquinaria y herramientas, constructora y barraca de fierros en Curicó, Maule. Catálogo online, cotizaciones rápidas y cobertura en Curicó, Romeral, Molina y Lontué."
+    />
+    <meta
+      name="keywords"
+      content="arriendo de maquinaria curico, constructora curico, barraca de fierros curico, arriendo de herramientas, maquinaria en maule, romeral, molina, lontue"
+    />
+    <meta name="author" content="JURMAQ" />
+    <meta property="og:title" content="JURMAQ | Maquinaria, construcción y barraca" />
+    <meta
+      property="og:description"
+      content="Arriendo de maquinaria y herramientas, servicios de construcción y venta de fierros en Curicó, Maule."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="es_CL" />
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "LocalBusiness",
+        "name": "JURMAQ",
+        "image": "https://jurmaq.cl/logo.png",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Curicó",
+          "addressRegion": "Maule",
+          "addressCountry": "CL"
+        },
+        "areaServed": ["Curicó", "Romeral", "Molina", "Lontué"],
+        "description": "Arriendo de maquinaria, constructora y barraca de fierros en Curicó, Maule.",
+        "url": "https://jurmaq.cl",
+        "telephone": "+56 9 0000 0000"
+      }
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container header-content">
+        <div class="brand">
+          <span class="brand-mark">JURMAQ</span>
+          <span class="brand-subtitle">Maestranza, Construcción y Arriendo</span>
+        </div>
+        <nav class="site-nav">
+          <a href="#servicios">Servicios</a>
+          <a href="#maquinaria">Maquinaria</a>
+          <a href="#catalogo">Catálogo</a>
+          <a href="#contacto">Contacto</a>
+        </nav>
+        <a class="btn btn-primary" href="#contacto">Cotiza Ahora</a>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="container hero-grid">
+          <div class="hero-copy">
+            <p class="eyebrow">Curicó • Maule</p>
+            <h1>Arriendo de maquinaria, herramientas y servicios de construcción en un solo lugar.</h1>
+            <p>
+              En JURMAQ reunimos constructora, arriendo de maquinaria y barraca de fierros para que tu obra
+              avance sin contratiempos. Publica tus requerimientos, revisa el catálogo y recibe una cotización rápida.
+            </p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="#maquinaria">Ver maquinaria disponible</a>
+              <a class="btn btn-ghost" href="#catalogo">Descargar catálogo</a>
+            </div>
+            <div class="hero-meta">
+              <div>
+                <strong>+30</strong>
+                <span>Equipos y herramientas</span>
+              </div>
+              <div>
+                <strong>24-48h</strong>
+                <span>Respuesta a cotizaciones</span>
+              </div>
+              <div>
+                <strong>4 comunas</strong>
+                <span>Curicó, Romeral, Molina, Lontué</span>
+              </div>
+            </div>
+          </div>
+          <div class="hero-card">
+            <h2>Solicita tu arriendo hoy</h2>
+            <p>Completa tus datos y recibe disponibilidad en minutos.</p>
+            <form class="lead-form">
+              <label>
+                Nombre y empresa
+                <input type="text" name="nombre" placeholder="Ej: Constructora Valle" />
+              </label>
+              <label>
+                Tipo de maquinaria o servicio
+                <input type="text" name="tipo" placeholder="Ej: minicargador, retroexcavadora" />
+              </label>
+              <label>
+                Comuna
+                <select name="comuna">
+                  <option>Curicó</option>
+                  <option>Romeral</option>
+                  <option>Molina</option>
+                  <option>Lontué</option>
+                </select>
+              </label>
+              <button type="button" class="btn btn-primary">Enviar solicitud</button>
+              <p class="form-note">También puedes escribirnos por WhatsApp para respuesta inmediata.</p>
+            </form>
+          </div>
+        </div>
+      </section>
+
+      <section id="servicios" class="section">
+        <div class="container">
+          <div class="section-heading">
+            <h2>Todo lo que necesitas para tu proyecto</h2>
+            <p>
+              Somos una empresa familiar de Curicó especializada en construcción, maestranza y arriendo. Nuestro
+              objetivo es que encuentres soluciones de manera rápida y confiable.
+            </p>
+          </div>
+          <div class="cards-grid">
+            <article class="card">
+              <h3>Arriendo de maquinaria</h3>
+              <p>
+                Equipos para movimiento de tierra, compactación, elevación y obras civiles. Mantención al día y
+                asesoría en terreno.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Herramientas y equipos menores</h3>
+              <p>
+                Rotomartillos, generadores, torres de iluminación, placas compactadoras y más para faenas pequeñas y
+                medianas.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Constructora y maestranza</h3>
+              <p>
+                Obras civiles, estructuras metálicas, montaje y fabricación a medida. Equipo técnico en Curicó y
+                alrededores.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Barraca de fierros</h3>
+              <p>
+                Perfil en fierro, acero y materiales para obras. Disponibilidad inmediata y despacho en la región del
+                Maule.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="maquinaria" class="section alt">
+        <div class="container">
+          <div class="section-heading">
+            <h2>Maquinaria destacada</h2>
+            <p>
+              Publicamos el estado, disponibilidad y tiempos de entrega. Si necesitas un equipo específico, lo
+              buscamos para ti.
+            </p>
+          </div>
+          <div class="cards-grid">
+            <article class="card">
+              <h3>Retroexcavadora</h3>
+              <p>Ideal para excavaciones, zanjeo y carguío. Operador opcional y combustible coordinado.</p>
+              <span class="pill">Disponible</span>
+            </article>
+            <article class="card">
+              <h3>Minicargador</h3>
+              <p>Compacto y versátil para movimiento de material en espacios reducidos.</p>
+              <span class="pill warning">Reserva anticipada</span>
+            </article>
+            <article class="card">
+              <h3>Camión tolva</h3>
+              <p>Transporte de áridos y retiro de escombros en Curicó, Romeral y Molina.</p>
+              <span class="pill">Disponible</span>
+            </article>
+            <article class="card">
+              <h3>Compresor y herramientas</h3>
+              <p>Equipos listos para trabajos de demolición, corte y perforación.</p>
+              <span class="pill">Disponible</span>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="catalogo" class="section">
+        <div class="container catalogo-grid">
+          <div>
+            <h2>Catálogo digital y publicaciones</h2>
+            <p>
+              Muy pronto podrás revisar el catálogo completo y publicar tus requerimientos directamente desde la
+              web. Mientras tanto, solicita el catálogo actualizado y recibe asesoría para elegir el equipo correcto.
+            </p>
+            <ul class="checklist">
+              <li>Actualización mensual de equipos disponibles.</li>
+              <li>Precios especiales por arriendos semanales y mensuales.</li>
+              <li>Soporte para obras en Curicó, Maule y alrededores.</li>
+            </ul>
+            <a class="btn btn-primary" href="#contacto">Solicitar catálogo</a>
+          </div>
+          <div class="catalogo-card">
+            <h3>¿Quieres publicar maquinaria?</h3>
+            <p>
+              Creamos un sistema simple para que puedas subir nuevas máquinas, herramientas y promociones desde el
+              celular.
+            </p>
+            <div class="steps">
+              <div>
+                <strong>1</strong>
+                <span>Sube fotos y detalles.</span>
+              </div>
+              <div>
+                <strong>2</strong>
+                <span>Define precio y disponibilidad.</span>
+              </div>
+              <div>
+                <strong>3</strong>
+                <span>Publica en minutos.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section alt" id="contacto">
+        <div class="container contact-grid">
+          <div>
+            <h2>Contacto directo</h2>
+            <p>
+              ¿Buscas arriendo de maquinaria en Curicó? Contacta a nuestro equipo en Curicó y recibe una propuesta
+              personalizada para tu proyecto.
+            </p>
+            <div class="contact-details">
+              <div>
+                <span>📍</span>
+                <div>
+                  <strong>Curicó, Maule</strong>
+                  <p>Atendemos Romeral, Molina, Lontué y alrededores.</p>
+                </div>
+              </div>
+              <div>
+                <span>📞</span>
+                <div>
+                  <strong>+56 9 0000 0000</strong>
+                  <p>WhatsApp disponible</p>
+                </div>
+              </div>
+              <div>
+                <span>✉️</span>
+                <div>
+                  <strong>contacto@jurmaq.cl</strong>
+                  <p>Respondemos en menos de 48 horas.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="contact-card">
+            <h3>Agenda una visita técnica</h3>
+            <p>Cuéntanos sobre tu obra y el equipo se coordinará contigo.</p>
+            <button class="btn btn-primary">Agendar ahora</button>
+            <button class="btn btn-ghost">Enviar WhatsApp</button>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container footer-grid">
+        <div>
+          <strong>JURMAQ</strong>
+          <p>Maestranza, construcción y arriendo de maquinaria en Curicó, Maule.</p>
+        </div>
+        <div>
+          <p><strong>Servicios</strong></p>
+          <ul>
+            <li>Arriendo de maquinaria</li>
+            <li>Herramientas y equipos</li>
+            <li>Constructora</li>
+            <li>Barraca de fierros</li>
+          </ul>
+        </div>
+        <div>
+          <p><strong>Ubicación</strong></p>
+          <p>Curicó • Romeral • Molina • Lontué</p>
+        </div>
+      </div>
+      <p class="footer-note">© 2024 JURMAQ. Todos los derechos reservados.</p>
+    </footer>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,391 @@
+:root {
+  color-scheme: light;
+  --primary: #1d4ed8;
+  --primary-dark: #1e3a8a;
+  --accent: #f97316;
+  --text: #0f172a;
+  --muted: #64748b;
+  --bg: #f8fafc;
+  --card: #ffffff;
+  --border: #e2e8f0;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: "Manrope", sans-serif;
+  color: var(--text);
+  background: var(--bg);
+  line-height: 1.6;
+}
+
+img {
+  max-width: 100%;
+}
+
+a {
+  text-decoration: none;
+  color: inherit;
+}
+
+ul {
+  list-style: none;
+  padding: 0;
+}
+
+.container {
+  width: min(1140px, 92%);
+  margin: 0 auto;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgba(255, 255, 255, 0.95);
+  border-bottom: 1px solid var(--border);
+  backdrop-filter: blur(8px);
+}
+
+.header-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 20px 0;
+}
+
+.brand {
+  display: flex;
+  flex-direction: column;
+}
+
+.brand-mark {
+  font-weight: 800;
+  font-size: 1.4rem;
+  letter-spacing: 0.08em;
+  color: var(--primary-dark);
+}
+
+.brand-subtitle {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.site-nav {
+  display: flex;
+  gap: 20px;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.site-nav a:hover {
+  color: var(--primary);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 22px;
+  border-radius: 999px;
+  font-weight: 600;
+  border: 1px solid transparent;
+  transition: all 0.2s ease;
+}
+
+.btn-primary {
+  background: var(--primary);
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(29, 78, 216, 0.2);
+}
+
+.btn-primary:hover {
+  background: var(--primary-dark);
+}
+
+.btn-ghost {
+  border-color: var(--border);
+  color: var(--primary-dark);
+  background: #fff;
+}
+
+.btn-ghost:hover {
+  border-color: var(--primary);
+  color: var(--primary);
+}
+
+.hero {
+  padding: 80px 0 60px;
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 40px;
+  align-items: center;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-weight: 700;
+  color: var(--accent);
+  margin-bottom: 16px;
+}
+
+.hero h1 {
+  font-size: clamp(2rem, 3vw, 3rem);
+  margin-bottom: 16px;
+}
+
+.hero-copy p {
+  color: var(--muted);
+  margin-bottom: 20px;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.hero-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 16px;
+  padding-top: 10px;
+}
+
+.hero-meta strong {
+  font-size: 1.25rem;
+  display: block;
+}
+
+.hero-card {
+  background: var(--card);
+  padding: 30px;
+  border-radius: 24px;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+}
+
+.lead-form {
+  display: grid;
+  gap: 16px;
+  margin-top: 20px;
+}
+
+.lead-form label {
+  display: grid;
+  gap: 8px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.lead-form input,
+.lead-form select {
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  font-size: 1rem;
+}
+
+.form-note {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.section {
+  padding: 70px 0;
+}
+
+.section.alt {
+  background: #eef2ff;
+}
+
+.section-heading {
+  max-width: 640px;
+  margin-bottom: 40px;
+}
+
+.section-heading h2 {
+  font-size: clamp(1.8rem, 2.5vw, 2.4rem);
+  margin-bottom: 12px;
+}
+
+.section-heading p {
+  color: var(--muted);
+}
+
+.cards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 24px;
+}
+
+.card {
+  background: var(--card);
+  padding: 24px;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.04);
+}
+
+.card h3 {
+  margin-bottom: 12px;
+}
+
+.card p {
+  color: var(--muted);
+}
+
+.pill {
+  display: inline-flex;
+  margin-top: 16px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: #dcfce7;
+  color: #166534;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.pill.warning {
+  background: #ffedd5;
+  color: #9a3412;
+}
+
+.catalogo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 32px;
+  align-items: center;
+}
+
+.checklist {
+  margin: 20px 0;
+  color: var(--muted);
+  display: grid;
+  gap: 10px;
+}
+
+.checklist li::before {
+  content: "✓";
+  margin-right: 8px;
+  color: var(--primary);
+  font-weight: 700;
+}
+
+.catalogo-card {
+  background: linear-gradient(135deg, #1d4ed8, #1e40af);
+  color: #fff;
+  padding: 32px;
+  border-radius: 24px;
+}
+
+.steps {
+  display: grid;
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.steps div {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.steps strong {
+  font-size: 1.4rem;
+  background: rgba(255, 255, 255, 0.2);
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.contact-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 32px;
+  align-items: center;
+}
+
+.contact-details {
+  display: grid;
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.contact-details div {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.contact-card {
+  background: var(--card);
+  border-radius: 24px;
+  padding: 32px;
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.08);
+  display: grid;
+  gap: 16px;
+}
+
+.site-footer {
+  padding: 40px 0 20px;
+  border-top: 1px solid var(--border);
+  background: #fff;
+}
+
+.footer-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 24px;
+}
+
+.footer-grid ul {
+  margin-top: 10px;
+  color: var(--muted);
+  display: grid;
+  gap: 6px;
+}
+
+.footer-note {
+  text-align: center;
+  color: var(--muted);
+  margin-top: 20px;
+  font-size: 0.85rem;
+}
+
+@media (max-width: 900px) {
+  .site-nav {
+    display: none;
+  }
+}
+
+@media (max-width: 600px) {
+  .header-content {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .hero {
+    padding-top: 60px;
+  }
+
+  .btn {
+    width: 100%;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a refreshed Spanish landing page for JURMAQ to improve local SEO and lead capture for Curicó, Romeral, Molina and Lontué.
- Offer a simple publishable catalog and contact flow so the business can list machinery, tools and request quotes from visitors.
- Deliver a clean, responsive UI that works on mobile and desktop and communicates services (constructora, arriendo de maquinaria, barraca).

### Description
- Added a new static landing page at `index.html` with SEO meta tags, Open Graph metadata and `application/ld+json` LocalBusiness structured data.
- Implemented a responsive stylesheet in `styles.css` covering header, hero, service cards, catalog section, contact card and a simple lead form.
- Included UI copy and components for publishing machinery, catalog requests and contact/WhatsApp calls-to-action, and fixed a small copy typo (`Curic using` → `Curicó`).
- Wired in Google Fonts and accessible layout patterns to support modern, mobile-first display.

### Testing
- Started a local server with `python -m http.server 8000` and verified the site served successfully on `http://127.0.0.1:8000`.
- Ran a Playwright script to load the page and capture a full-page screenshot which completed successfully and saved to `artifacts/jurmaq-home.png`.
- No unit tests were required because changes are static content and CSS only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69738432d7a4832fb26273b7835d5290)